### PR TITLE
Allow to configure a "generic" God watchers

### DIFF
--- a/lib/sidekiq-runner/god_configuration.rb
+++ b/lib/sidekiq-runner/god_configuration.rb
@@ -18,6 +18,8 @@ module SidekiqRunner
     CONFIG_FILE_ATTRIBUTES = [:process_name, :interval, :stop_timeout, :log_file, :log_level, :maximum_memory_usage, :pid]
     CONFIG_FILE_ATTRIBUTES.each { |att| attr_accessor att }
 
+    attr_reader :generic_watchers
+
     def initialize
       @process_name = 'sidekiq'
       @interval  = 30
@@ -36,6 +38,12 @@ module SidekiqRunner
       # This is going to be a part of the .sock file name e.g. "/tmp/god.17165.sock" and the pidfile name
       # Change this in the configuration file to be able to run multiple instances of god.
       @port = 17165
+
+      @generic_watchers = []
+    end
+
+    def add_generic(&blk)
+      @generic_watchers << blk
     end
 
     def options

--- a/lib/sidekiq-runner/sidekiq.god
+++ b/lib/sidekiq-runner/sidekiq.god
@@ -6,6 +6,12 @@ god_config = SidekiqRunner::GodConfiguration.get
 
 God.terminate_timeout = god_config.stop_timeout + 10
 
+god_config.generic_watchers.each do |block|
+  God.watch do |w|
+    block.call(w)
+  end
+end
+
 sidekiq_config.each do |name, skiq|
   God.watch do |w|
     w.name = name

--- a/sidekiq-runner.gemspec
+++ b/sidekiq-runner.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.files         = Dir.glob('lib/**/*.rb') + ['lib/sidekiq-runner/sidekiq.god'] + Dir.glob('script/*')
 
-  s.add_dependency 'rake', '~> 10.3'
+  s.add_dependency 'rake'
   s.add_dependency 'god', '~> 0.13'
 end


### PR DESCRIPTION
With this change one can add non Sidekiq processes to the SidekiqRunner
god instance.

```ruby
SidekiqRunner.configure_god do |config|
  config.add_generic do |w|
    w.name = "some_process"
    w.start = "bundle exec some_process"
    w.keepalive
  end
end
```