### PR TITLE
Adapt to Sidekiq 6

### DIFF
--- a/lib/sidekiq-runner.rb
+++ b/lib/sidekiq-runner.rb
@@ -48,6 +48,17 @@ module SidekiqRunner
     end
   end
 
+  def self.restart(sidekiq_instances: [])
+    sidekiq_config = SidekiqConfiguration.get
+    god_config = GodConfiguration.get
+
+    return unless god_alive?(god_config)
+
+    sidekiq_config.each_key do |name|
+      God::CLI::Command.new('restart', god_config.options, ['', name]) if sidekiq_instances.empty? || sidekiq_instances.include?(name.to_sym)
+    end
+  end
+
   def self.running?
     god_alive? GodConfiguration.get
   end

--- a/lib/sidekiq-runner/sidekiq.god
+++ b/lib/sidekiq-runner/sidekiq.god
@@ -19,6 +19,9 @@ sidekiq_config.each do |name, skiq|
     # Set start command.
     w.start = skiq.build_start_command
 
+    # Set logfile
+    w.log = skiq.logfile
+
     # Set stop command.
     w.stop = skiq.build_stop_command(god_config.stop_timeout)
     w.stop_timeout = god_config.stop_timeout

--- a/lib/sidekiq-runner/sidekiq.god
+++ b/lib/sidekiq-runner/sidekiq.god
@@ -23,7 +23,6 @@ sidekiq_config.each do |name, skiq|
     w.log = skiq.logfile
 
     # Set stop command.
-    w.stop = skiq.build_stop_command(god_config.stop_timeout)
     w.stop_timeout = god_config.stop_timeout
 
     # Set uid/gid if requested.

--- a/lib/sidekiq-runner/sidekiq.god
+++ b/lib/sidekiq-runner/sidekiq.god
@@ -26,10 +26,6 @@ sidekiq_config.each do |name, skiq|
     w.stop = skiq.build_stop_command(god_config.stop_timeout)
     w.stop_timeout = god_config.stop_timeout
 
-    # Make sure the pidfile is deleted as sidekiqctl does not delete stale pidfiles.
-    w.pid_file = skiq.pidfile
-    w.behavior(:clean_pid_file)
-
     # Set uid/gid if requested.
     w.uid = skiq.uid if skiq.uid
     w.gid = skiq.gid if skiq.gid

--- a/lib/sidekiq-runner/sidekiq_configuration.rb
+++ b/lib/sidekiq-runner/sidekiq_configuration.rb
@@ -12,7 +12,7 @@ module SidekiqRunner
     def initialize
       @config_file =
         if defined?(Rails)
-          File.join(Rails.root, 'config', 'sidekiq.yml')  
+          File.join(Rails.root, 'config', 'sidekiq.yml')
         else
           File.join(Dir.pwd, 'config', 'sidekiq.yml')
         end

--- a/lib/sidekiq-runner/sidekiq_configuration.rb
+++ b/lib/sidekiq-runner/sidekiq_configuration.rb
@@ -86,8 +86,6 @@ module SidekiqRunner
     end
 
     def merge_config_file!
-      sidekiqs_common_config = {}
-
       yml = File.exist?(config_file) ? YAML.load_file(config_file) : {}
       yml = Hash[yml.map { |k, v| [k.to_sym, v] }]
 
@@ -96,8 +94,6 @@ module SidekiqRunner
 
     def sane?
       fail 'No sidekiq instances defined. Nothing to run.' if @sidekiqs.empty?
-      fail 'Sidekiq instances with the same pidfile found.' if @sidekiqs.values.map(&:pidfile).uniq.size < @sidekiqs.size
-      fail 'Sidekiq instances with the same logfile found.' if @sidekiqs.values.map(&:logfile).uniq.size < @sidekiqs.size
 
       @sidekiqs.each_value { |skiq| skiq.sane? }
     end

--- a/lib/sidekiq-runner/sidekiq_instance.rb
+++ b/lib/sidekiq-runner/sidekiq_instance.rb
@@ -1,6 +1,5 @@
 module SidekiqRunner
   class SidekiqInstance
-
     RUNNER_ATTRIBUTES = [:bundle_env, :chdir, :requirefile]
     RUNNER_ATTRIBUTES.each { |att| attr_accessor att }
 
@@ -10,7 +9,7 @@ module SidekiqRunner
     attr_reader :name, :queues, :config_blocks
 
     def initialize(name)
-      fail "No sidekiq instance name given!" if name.empty?
+      raise "No sidekiq instance name given!" if name.empty?
 
       @name = name
       @queues = []
@@ -30,9 +29,10 @@ module SidekiqRunner
     end
 
     def add_queue(queue_name, weight = 1)
-      fail "Cannot add the queue. The name is empty!" if queue_name.empty?
-      fail "Cannot add the queue. The weight is not an integer!" unless weight.is_a? Integer
-      fail "Cannot add the queue. The queue with \"#{queue_name}\" name already exist" if @queues.any? { |q| q.first == queue_name }
+      raise "Cannot add the queue. The name is empty!" if queue_name.empty?
+      raise "Cannot add the queue. The weight is not an integer!" unless weight.is_a? Integer
+      raise "Cannot add the queue. The queue with \"#{queue_name}\" name already exist" if @queues.any? { |q| q.first == queue_name }
+
       @queues << [queue_name, weight]
     end
 
@@ -47,7 +47,7 @@ module SidekiqRunner
       end
 
       # Override with instance-specific options.
-      if (syml = yml[@name.to_sym]) && (syml.is_a?(Hash))
+      if (syml = yml[@name.to_sym]) && syml.is_a?(Hash)
         syml = Hash[syml.map { |k, v| [k.to_sym, v] }]
 
         SidekiqInstance::CONFIG_FILE_ATTRIBUTES.each do |k|
@@ -57,8 +57,8 @@ module SidekiqRunner
     end
 
     def sane?
-      fail "No queues given for #{@name}!" if @queues.empty?  
-      fail "No requirefile given for #{@name} and not in Rails environment!" if !defined?(Rails) && !requirefile
+      raise "No queues given for #{@name}!" if @queues.empty?
+      raise "No requirefile given for #{@name} and not in Rails environment!" if !defined?(Rails) && !requirefile
     end
 
     def build_start_command
@@ -66,7 +66,7 @@ module SidekiqRunner
 
       cmd = []
       cmd << 'bundle exec' if bundle_env
-      cmd << (rbtrace ? File.expand_path('../../../script/sidekiq_rbtrace', __FILE__) : 'sidekiq')
+      cmd << (rbtrace ? File.expand_path('../../script/sidekiq_rbtrace', __dir__) : 'sidekiq')
       cmd << "-c #{concurrency}"
       cmd << '-v' if verbose
       cmd << "-P #{pidfile}"
@@ -75,7 +75,7 @@ module SidekiqRunner
       cmd << "-g '#{tag}'"
 
       queues.each do |q, w|
-        cmd << "-q #{q},#{w.to_s}"
+        cmd << "-q #{q},#{w}"
       end
 
       # Sidekiq 6 does not log to files anymore

--- a/lib/sidekiq-runner/sidekiq_instance.rb
+++ b/lib/sidekiq-runner/sidekiq_instance.rb
@@ -81,16 +81,6 @@ module SidekiqRunner
       cmd.join(' ')
     end
 
-    def build_stop_command(timeout)
-      cmd = []
-      cmd << (bundle_env ? 'bundle exec sidekiqctl' : 'sidekiqctl')
-      cmd << 'stop'
-      cmd << pidfile
-      cmd << timeout
-
-      cmd.join(' ')
-    end
-
     private
 
     def create_directories!

--- a/lib/sidekiq-runner/sidekiq_instance.rb
+++ b/lib/sidekiq-runner/sidekiq_instance.rb
@@ -78,9 +78,6 @@ module SidekiqRunner
         cmd << "-q #{q},#{w}"
       end
 
-      # Sidekiq 6 does not log to files anymore
-      cmd << "2>&1 >> #{logfile}"
-
       cmd.join(' ')
     end
 

--- a/lib/sidekiq-runner/sidekiq_instance.rb
+++ b/lib/sidekiq-runner/sidekiq_instance.rb
@@ -67,10 +67,8 @@ module SidekiqRunner
       cmd = []
       cmd << 'bundle exec' if bundle_env
       cmd << (rbtrace ? File.expand_path('../../../script/sidekiq_rbtrace', __FILE__) : 'sidekiq')
-      cmd << '-d'
       cmd << "-c #{concurrency}"
       cmd << '-v' if verbose
-      cmd << "-L #{logfile}"
       cmd << "-P #{pidfile}"
       cmd << "-e #{Rails.env}" if defined?(Rails)
       cmd << "-r #{requirefile}" if requirefile
@@ -79,6 +77,9 @@ module SidekiqRunner
       queues.each do |q, w|
         cmd << "-q #{q},#{w.to_s}"
       end
+
+      # Sidekiq 6 does not log to files anymore
+      cmd << "2>&1 >> #{logfile}"
 
       cmd.join(' ')
     end

--- a/sidekiq-runner.gemspec
+++ b/sidekiq-runner.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rake'
   s.add_dependency 'god', '~> 0.13'
+  s.add_dependency 'sidekiq', '~> 6.0'
 end


### PR DESCRIPTION
We need to change the following things:
* do not rely on `Sidekiq` logging anymore, but redirect `STDOUT` and `STDERR` to a file with `God`
* allow to restart individual `Sidekiq` instances inside of `God`
* remove the usage of `sidekiqctl` and rely on normal signals instead
* do not clean up pids anymore, because sidekiq does not create any anymore