### PR TITLE
Switch from `god` to `resurrected_god`

### DIFF
--- a/sidekiq-runner.gemspec
+++ b/sidekiq-runner.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |s|
   s.files         = Dir.glob('lib/**/*.rb') + ['lib/sidekiq-runner/sidekiq.god'] + Dir.glob('script/*')
 
   s.add_dependency 'rake'
-  s.add_dependency 'god', '~> 0.13'
+  s.add_dependency 'resurrected_god', '~> 1'
   s.add_dependency 'sidekiq', '~> 6.0'
 end


### PR DESCRIPTION
For us the main benefit (for now) is support for newer `timeout` gem versions that do not patch `Object` anymore. They also seems to be prepared for newer ruby versions.

https://github.com/mishina2228/resurrected_god/releases